### PR TITLE
Fix typo in arc trig functions .eg acos

### DIFF
--- a/calc.js
+++ b/calc.js
@@ -55,7 +55,7 @@ function calc() {
     _(['asin', 'acos', 'atan', 'atan2']).each(function(name) {
         var fn = math[name]; // the original function
         replacements[name] = function replacement(x) {
-            return Calc.convertRadians(fn(x));
+            return Calc.convRadians(fn(x));
         };
     });
 


### PR DESCRIPTION
Thank you @yerich for the interesting project!

There is no static function `convertRadians` so I assume this is a typo? Before the change I cannot graph any arc trigonometric functions such `acos`, after my patch it works as expected.